### PR TITLE
23 implement the gravity boosts entity in the backend and database

### DIFF
--- a/backend/Entities/GravityBoosts.cs
+++ b/backend/Entities/GravityBoosts.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace StudyVerseBackend.Entities;
+
+public class GravityBoosts
+{
+    [Key]
+    public int Boost_Id { get; set; }
+    [Required]
+    public string Message { get; set; }
+    public DateTimeOffset Sent_At { get; set; } = DateTimeOffset.Now;
+    [Required]
+    public String Sender_Id { get; set; }
+    public User Sender_User { get; set; }
+    [Required]
+    public String Receiver_Id { get; set; }
+    public User Receiver { get; set; }
+}

--- a/backend/Entities/GravityBoosts.cs
+++ b/backend/Entities/GravityBoosts.cs
@@ -11,7 +11,7 @@ public class GravityBoosts
     public DateTimeOffset Sent_At { get; set; } = DateTimeOffset.Now;
     [Required]
     public String Sender_Id { get; set; }
-    public User Sender_User { get; set; }
+    public User Sender { get; set; }
     [Required]
     public String Receiver_Id { get; set; }
     public User Receiver { get; set; }

--- a/backend/Infastructure/Contexts/ApplicationDbContext.cs
+++ b/backend/Infastructure/Contexts/ApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using StudyVerseBackend.Entities;
+using System.Reflection.Emit;
 
 namespace StudyVerseBackend.Infastructure.Contexts;
 
@@ -14,8 +15,8 @@ public class ApplicationDbContext
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
     {
     }
-    
-    public DbSet<GravityBoosts> GravityBoosts { get; set;}
+
+    public DbSet<GravityBoosts> GravityBoosts { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -32,6 +33,17 @@ public class ApplicationDbContext
         builder.Entity<User>()
             .Property(u => u.CustomizationOptions)
             .HasColumnType("jsonb");
+
+        // Code dealing with GravityBoosts
+        builder.Entity<GravityBoosts>()
+            .HasOne(gb => gb.Sender)
+            .WithMany()
+            .HasForeignKey(gb => gb.Sender_Id);
+
+        builder.Entity<GravityBoosts>()
+            .HasOne(gb => gb.Receiver)
+            .WithMany()
+            .HasForeignKey(gb => gb.Receiver_Id);
     }
 
 }

--- a/backend/Infastructure/Contexts/ApplicationDbContext.cs
+++ b/backend/Infastructure/Contexts/ApplicationDbContext.cs
@@ -14,6 +14,8 @@ public class ApplicationDbContext
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
     {
     }
+    
+    public DbSet<GravityBoosts> GravityBoosts { get; set;}
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/backend/Migrations/20250314182226_GravityBoostsTable.Designer.cs
+++ b/backend/Migrations/20250314182226_GravityBoostsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using StudyVerseBackend.Infastructure.Contexts;
@@ -11,9 +12,11 @@ using StudyVerseBackend.Infastructure.Contexts;
 namespace StudyVerseBackend.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250314182226_GravityBoostsTable")]
+    partial class GravityBoostsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20250314182226_GravityBoostsTable.cs
+++ b/backend/Migrations/20250314182226_GravityBoostsTable.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace StudyVerseBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class GravityBoostsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GravityBoosts",
+                columns: table => new
+                {
+                    Boost_Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Message = table.Column<string>(type: "text", nullable: false),
+                    Sent_At = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Sender_Id = table.Column<string>(type: "text", nullable: false),
+                    Receiver_Id = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GravityBoosts", x => x.Boost_Id);
+                    table.ForeignKey(
+                        name: "FK_GravityBoosts_AspNetUsers_Receiver_Id",
+                        column: x => x.Receiver_Id,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_GravityBoosts_AspNetUsers_Sender_Id",
+                        column: x => x.Sender_Id,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GravityBoosts_Receiver_Id",
+                table: "GravityBoosts",
+                column: "Receiver_Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GravityBoosts_Sender_Id",
+                table: "GravityBoosts",
+                column: "Sender_Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GravityBoosts");
+        }
+    }
+}


### PR DESCRIPTION
I represented the Gravity Boosts table in dotnet, made the migration and can successfully view the table in the database.